### PR TITLE
bugfix: prevent overflow

### DIFF
--- a/src/main/java/clearcl/ocllib/kernels/projections.cl
+++ b/src/main/java/clearcl/ocllib/kernels/projections.cl
@@ -6,7 +6,7 @@ __kernel void sum_project_3d_2d(
 
   const int x = get_global_id(0);
   const int y = get_global_id(1);
-  DTYPE_IN sum = 0;
+  float sum = 0;
   for(int z = 0; z < GET_IMAGE_IN_DEPTH(src); z++)
   {
     sum = sum + READ_IMAGE_3D(src,sampler,(int4)(x,y,z,0)).x;


### PR DESCRIPTION
 in case of summing 8-bit or 18-bit images with high pixel values and/or many slices

This is a copy of the bugifx in clij-core:
https://github.com/clij/clij-core/commit/e42a13529b33594fc37cf540d3e5be554dcfba11

I didn't fix commented out methods; this might be necessary in case you would like to un-comment them later...